### PR TITLE
Encapsulate FieldMetadata

### DIFF
--- a/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
+++ b/datafusion/core/tests/user_defined/user_defined_scalar_functions.rs
@@ -40,6 +40,7 @@ use datafusion_common::{
     assert_batches_eq, assert_batches_sorted_eq, assert_contains, exec_err, not_impl_err,
     plan_err, DFSchema, DataFusionError, Result, ScalarValue,
 };
+use datafusion_expr::expr::FieldMetadata;
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyInfo};
 use datafusion_expr::{
     lit_with_metadata, Accumulator, ColumnarValue, CreateFunction, CreateFunctionBody,
@@ -1539,7 +1540,7 @@ async fn test_metadata_based_udf_with_literal() -> Result<()> {
     let df = ctx.sql("select 0;").await?.select(vec![
         lit(5u64).alias_with_metadata("lit_with_doubling", Some(input_metadata.clone())),
         lit(5u64).alias("lit_no_doubling"),
-        lit_with_metadata(5u64, Some(input_metadata))
+        lit_with_metadata(5u64, Some(FieldMetadata::from(input_metadata)))
             .alias("lit_with_double_no_alias_metadata"),
     ])?;
 

--- a/datafusion/expr/src/expr_rewriter/mod.rs
+++ b/datafusion/expr/src/expr_rewriter/mod.rs
@@ -390,11 +390,7 @@ mod test {
                     } else {
                         utf8_val
                     };
-                    Ok(Transformed::yes(lit_with_metadata(
-                        utf8_val,
-                        metadata
-                            .map(|m| m.into_iter().collect::<HashMap<String, String>>()),
-                    )))
+                    Ok(Transformed::yes(lit_with_metadata(utf8_val, metadata)))
                 }
                 // otherwise, return None
                 _ => Ok(Transformed::no(expr)),

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -423,12 +423,7 @@ impl ExprSchemable for Expr {
             Expr::Literal(l, metadata) => {
                 let mut field = Field::new(&schema_name, l.data_type(), l.is_null());
                 if let Some(metadata) = metadata {
-                    field = field.with_metadata(
-                        metadata
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                    );
+                    field = metadata.add_to_field(field);
                 }
                 Ok(Arc::new(field))
             }

--- a/datafusion/expr/src/literal.rs
+++ b/datafusion/expr/src/literal.rs
@@ -17,20 +17,16 @@
 
 //! Literal module contains foundational types that are used to represent literals in DataFusion.
 
+use crate::expr::FieldMetadata;
 use crate::Expr;
 use datafusion_common::ScalarValue;
-use std::collections::HashMap;
 
 /// Create a literal expression
 pub fn lit<T: Literal>(n: T) -> Expr {
     n.lit()
 }
 
-pub fn lit_with_metadata<T: Literal>(
-    n: T,
-    metadata: impl Into<Option<HashMap<String, String>>>,
-) -> Expr {
-    let metadata = metadata.into();
+pub fn lit_with_metadata<T: Literal>(n: T, metadata: Option<FieldMetadata>) -> Expr {
     let Some(metadata) = metadata else {
         return n.lit();
     };
@@ -38,13 +34,12 @@ pub fn lit_with_metadata<T: Literal>(
     let Expr::Literal(sv, prior_metadata) = n.lit() else {
         unreachable!();
     };
-
     let new_metadata = match prior_metadata {
         Some(mut prior) => {
             prior.extend(metadata);
             prior
         }
-        None => metadata.into_iter().collect(),
+        None => metadata,
     };
 
     Expr::Literal(sv, Some(new_metadata))

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -18,7 +18,6 @@
 //! Literal expressions for physical operations
 
 use std::any::Any;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -30,6 +29,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use datafusion_common::{Result, ScalarValue};
+use datafusion_expr::expr::FieldMetadata;
 use datafusion_expr::Expr;
 use datafusion_expr_common::columnar_value::ColumnarValue;
 use datafusion_expr_common::interval_arithmetic::Interval;
@@ -64,14 +64,13 @@ impl Literal {
     /// Create a literal value expression
     pub fn new_with_metadata(
         value: ScalarValue,
-        metadata: impl Into<Option<HashMap<String, String>>>,
+        metadata: Option<FieldMetadata>,
     ) -> Self {
-        let metadata = metadata.into();
         let mut field =
             Field::new(format!("{value}"), value.data_type(), value.is_null());
 
         if let Some(metadata) = metadata {
-            field = field.with_metadata(metadata);
+            field = metadata.add_to_field(field);
         }
 
         Self {

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::ScalarFunctionExpr;
@@ -29,7 +28,9 @@ use datafusion_common::{
     exec_err, not_impl_err, plan_err, DFSchema, Result, ScalarValue, ToDFSchema,
 };
 use datafusion_expr::execution_props::ExecutionProps;
-use datafusion_expr::expr::{Alias, Cast, InList, Placeholder, ScalarFunction};
+use datafusion_expr::expr::{
+    Alias, Cast, FieldMetadata, InList, Placeholder, ScalarFunction,
+};
 use datafusion_expr::var_provider::is_system_variables;
 use datafusion_expr::var_provider::VarType;
 use datafusion_expr::{
@@ -114,21 +115,25 @@ pub fn create_physical_expr(
     match e {
         Expr::Alias(Alias { expr, metadata, .. }) => {
             if let Expr::Literal(v, prior_metadata) = expr.as_ref() {
-                let mut new_metadata = prior_metadata
-                    .as_ref()
-                    .map(|m| {
-                        m.iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect::<HashMap<String, String>>()
-                    })
-                    .unwrap_or_default();
-                if let Some(metadata) = metadata {
-                    new_metadata.extend(metadata.clone());
-                }
-                let new_metadata = match new_metadata.is_empty() {
-                    true => None,
-                    false => Some(new_metadata),
+                let metadata = metadata.as_ref().map(|m| FieldMetadata::from(m.clone()));
+                let new_metadata = match (prior_metadata.as_ref(), metadata) {
+                    (Some(m), Some(n)) => {
+                        let mut m = m.clone();
+                        m.extend(n);
+                        Some(m)
+                    }
+                    (Some(m), None) => Some(m.clone()),
+                    (None, Some(n)) => Some(n),
+                    (None, None) => None,
                 };
+
+                let new_metadata = new_metadata.and_then(|new_metadata| {
+                    if new_metadata.is_empty() {
+                        None
+                    } else {
+                        Some(new_metadata)
+                    }
+                });
 
                 Ok(Arc::new(Literal::new_with_metadata(
                     v.clone(),
@@ -144,9 +149,7 @@ pub fn create_physical_expr(
         }
         Expr::Literal(value, metadata) => Ok(Arc::new(Literal::new_with_metadata(
             value.clone(),
-            metadata
-                .as_ref()
-                .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
+            metadata.clone(),
         ))),
         Expr::ScalarVariable(_, variable_names) => {
             if is_system_variables(variable_names) {


### PR DESCRIPTION
## Which issue does this PR close?

- Targets https://github.com/apache/datafusion/pull/16170

## Rationale for this change

As we begin supporting metadata from Fields I think keeping it encapsulated in a struct will help. Also making it cheaper to Clone will be important

## What changes are included in this PR?

1. Encapsulate the representation of metadata into a struct
2. Wrap the inner with an `Arc` to make it fast to clone

## Are these changes tested?
By unit tests 
## Are there any user-facing changes?

The API is different. Since we haven't merged https://github.com/apache/datafusion/pull/16170 yet I don't think there are any user visible changes
